### PR TITLE
Fixed wrong recording of winnerElo and loserElo for matches

### DIFF
--- a/app/routes/duel.tsx
+++ b/app/routes/duel.tsx
@@ -87,8 +87,8 @@ export const action: ActionFunction = async ({ request }) => {
       const match = await recordMatch(
         winnerId,
         loserId,
-        newELOPlayer1,
-        newELOPlayer2
+        player1IsWinner ? newELOPlayer1 : newELOPlayer2,
+          player1IsWinner ? newELOPlayer2 : newELOPlayer1
       );
       await updateELO(player1.id, newELOPlayer1);
       await logIndividualELO(player1.id, newELOPlayer1, match.id); // Log the new ELO for player 1


### PR DESCRIPTION
Siden det har vært registrert `winnerELO` alltid på `player1` sin nye ELO på matcher så vil `winnerELO` og `loserELO` være feil på de tilfellene der `player2` vinner. Dette har ikke påvirket registrering av individuell ELO, men har påvirket all ELO registrert på matcher hvor `player2` er vinner, så å bruke `winnerELO` og `loserELO` for tidligere matcher er ikke nødvendigvis riktig.